### PR TITLE
Replace SimpleDateFormat with DateTimeFormatter

### DIFF
--- a/00-ps-core/src/main/java/com/ps/util/DateFormatter.java
+++ b/00-ps-core/src/main/java/com/ps/util/DateFormatter.java
@@ -3,7 +3,11 @@ package com.ps.util;
 import org.springframework.format.Formatter;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
 
@@ -11,15 +15,19 @@ import java.util.Locale;
  * Created by iuliana.cosmina on 2/7/16.
  */
 public class DateFormatter implements Formatter<Date> {
-    public static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
 
     @Override
     public Date parse(String s, Locale locale) throws ParseException {
-        return formatter.parse(s);
+        LocalDateTime localDateTime = LocalDate.from(FORMATTER.parse(s)).atStartOfDay();
+        Instant instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
+        return Date.from(instant);
     }
 
     @Override
     public String print(Date date, Locale locale) {
-        return formatter.format(date);
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+        return FORMATTER.format(localDateTime);
     }
 }


### PR DESCRIPTION
SimpleDateFormat is not thread-safe and should not be used as static field